### PR TITLE
Add active FTB Ranks lookup for online players. Fixes bug in SDLink where conditon ranks in FTB Teams do not work.

### DIFF
--- a/src/api/java/com/hypherionmc/craterlib/api/compat/ftbranks/FTBRanks.java
+++ b/src/api/java/com/hypherionmc/craterlib/api/compat/ftbranks/FTBRanks.java
@@ -1,6 +1,7 @@
 package com.hypherionmc.craterlib.api.compat.ftbranks;
 
 import com.hypherionmc.craterlib.api.game.authlib.CraterGameProfile;
+import com.hypherionmc.craterlib.api.game.world.entity.player.CraterPlayer;
 import com.hypherionmc.craterlib.core.services.CraterServices;
 
 import java.util.List;
@@ -12,8 +13,10 @@ public interface FTBRanks {
     }
 
     List<? extends CraterFTBRank> getPlayerRanks(CraterGameProfile profile);
+    List<? extends CraterFTBRank> getPlayerRanks(CraterPlayer player);
     List<? extends CraterFTBRank> getAllRanks();
     boolean hasRank(CraterGameProfile profile, String rank);
+    boolean hasRank(CraterPlayer player, String rank);
     boolean addRank(CraterGameProfile profile, String rank);
     boolean removeRank(CraterGameProfile profile, String rank);
 

--- a/src/main/java/com/hypherionmc/craterlib/impl/compat/ftb/FTBRanksImpl.java
+++ b/src/main/java/com/hypherionmc/craterlib/impl/compat/ftb/FTBRanksImpl.java
@@ -6,7 +6,7 @@ import com.hypherionmc.craterlib.api.game.authlib.CraterGameProfile;
 import com.hypherionmc.craterlib.api.game.world.entity.player.CraterPlayer;
 import com.hypherionmc.craterlib.core.event.CraterEventBus;
 import com.hypherionmc.craterlib.impl.api.authlib.BridgedGameProfile;
-//import dev.ftb.mods.ftblibrary.platform.event.NativeEventPosting; Appears Unused
+import dev.ftb.mods.ftblibrary.platform.event.NativeEventPosting;
 import dev.ftb.mods.ftbranks.api.FTBRanksAPI;
 import dev.ftb.mods.ftbranks.api.event.PlayerAddedToRankEvent;
 import dev.ftb.mods.ftbranks.api.event.PlayerRemovedFromRankEvent;

--- a/src/main/java/com/hypherionmc/craterlib/impl/compat/ftb/FTBRanksImpl.java
+++ b/src/main/java/com/hypherionmc/craterlib/impl/compat/ftb/FTBRanksImpl.java
@@ -6,7 +6,7 @@ import com.hypherionmc.craterlib.api.game.authlib.CraterGameProfile;
 import com.hypherionmc.craterlib.api.game.world.entity.player.CraterPlayer;
 import com.hypherionmc.craterlib.core.event.CraterEventBus;
 import com.hypherionmc.craterlib.impl.api.authlib.BridgedGameProfile;
-import dev.ftb.mods.ftblibrary.platform.event.NativeEventPosting;
+//import dev.ftb.mods.ftblibrary.platform.event.NativeEventPosting; Appears Unused
 import dev.ftb.mods.ftbranks.api.FTBRanksAPI;
 import dev.ftb.mods.ftbranks.api.event.PlayerAddedToRankEvent;
 import dev.ftb.mods.ftbranks.api.event.PlayerRemovedFromRankEvent;
@@ -23,15 +23,15 @@ public class FTBRanksImpl implements FTBRanks {
 
     @Override
     public List<FTBRankImpl> getPlayerRanks(CraterGameProfile profile) {
-        return FTBRanksAPI.manager().getAddedRanks(((BridgedGameProfile) profile).toNameAndId()).stream().map(FTBRankImpl::wrap).toList();
         // Explicitly added ranks via "/ftbranks add player rank"
+        return FTBRanksAPI.manager().getAddedRanks(((BridgedGameProfile) profile).toNameAndId()).stream().map(FTBRankImpl::wrap).toList();
     }
 
     @Override
     public List<FTBRankImpl> getPlayerRanks(CraterPlayer player) {
+        // All ranks the player has. Includes explicitly added ranks and condition-added ranks.
         ServerPlayer serverPlayer = player.unwrap();
         return FTBRanksAPI.manager().getRanks(serverPlayer).stream().map(FTBRankImpl::wrap).toList();
-        // All ranks the player has. Includes explicitly added ranks and condition-added ranks.
     }
 
     public List<FTBRankImpl> getAllRanks() {
@@ -40,18 +40,18 @@ public class FTBRanksImpl implements FTBRanks {
 
     @Override
     public boolean hasRank(CraterGameProfile profile, String rank) {
+        //Original method for compatibility and for SDLink Discord2Minecraft
         return getPlayerRanks(profile)
                 .stream()
                 .anyMatch(r -> r.unwrapInternal().getName().equalsIgnoreCase(rank) || r.unwrapInternal().getId().equalsIgnoreCase(rank));
-        //Original method for compatibility and for SDLink Discord2Minecraft
     }
     
     @Override
     public boolean hasRank(CraterPlayer player, String rank) {
+        //Updated Method using ServerPlayer
         return getPlayerRanks(player)
                 .stream()
                 .anyMatch(r -> r.unwrapInternal().getName().equalsIgnoreCase(rank) || r.unwrapInternal().getId().equalsIgnoreCase(rank));
-        //Updated Method using ServerPlayer
     }
 
     public boolean addRank(CraterGameProfile profile, String rank) {

--- a/src/main/java/com/hypherionmc/craterlib/impl/compat/ftb/FTBRanksImpl.java
+++ b/src/main/java/com/hypherionmc/craterlib/impl/compat/ftb/FTBRanksImpl.java
@@ -3,6 +3,7 @@ package com.hypherionmc.craterlib.impl.compat.ftb;
 import com.hypherionmc.craterlib.api.compat.ftbranks.FTBRanks;
 import com.hypherionmc.craterlib.api.events.compat.FTBRankEvents;
 import com.hypherionmc.craterlib.api.game.authlib.CraterGameProfile;
+import com.hypherionmc.craterlib.api.game.world.entity.player.CraterPlayer;
 import com.hypherionmc.craterlib.core.event.CraterEventBus;
 import com.hypherionmc.craterlib.impl.api.authlib.BridgedGameProfile;
 import dev.ftb.mods.ftblibrary.platform.event.NativeEventPosting;
@@ -10,7 +11,7 @@ import dev.ftb.mods.ftbranks.api.FTBRanksAPI;
 import dev.ftb.mods.ftbranks.api.event.PlayerAddedToRankEvent;
 import dev.ftb.mods.ftbranks.api.event.PlayerRemovedFromRankEvent;
 import dev.ftb.mods.ftbranks.api.event.RankDeletedEvent;
-
+import net.minecraft.server.level.ServerPlayer;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -20,16 +21,31 @@ public class FTBRanksImpl implements FTBRanks {
 
     private FTBRanksImpl() {}
 
+    @Override
     public List<FTBRankImpl> getPlayerRanks(CraterGameProfile profile) {
         return FTBRanksAPI.manager().getAddedRanks(((BridgedGameProfile) profile).toNameAndId()).stream().map(FTBRankImpl::wrap).toList();
+    }
+
+    @Override
+    public List<FTBRankImpl> getPlayerRanks(CraterPlayer player) {
+        ServerPlayer serverPlayer = player.unwrap();
+        return FTBRanksAPI.manager().getRanks(serverPlayer).stream().map(FTBRankImpl::wrap).toList();
     }
 
     public List<FTBRankImpl> getAllRanks() {
         return FTBRanksAPI.manager().getAllRanks().stream().map(FTBRankImpl::wrap).toList();
     }
 
+    @Override
     public boolean hasRank(CraterGameProfile profile, String rank) {
         return getPlayerRanks(profile)
+                .stream()
+                .anyMatch(r -> r.unwrapInternal().getName().equalsIgnoreCase(rank) || r.unwrapInternal().getId().equalsIgnoreCase(rank));
+    }
+    
+    @Override
+    public boolean hasRank(CraterPlayer player, String rank) {
+        return getPlayerRanks(player)
                 .stream()
                 .anyMatch(r -> r.unwrapInternal().getName().equalsIgnoreCase(rank) || r.unwrapInternal().getId().equalsIgnoreCase(rank));
     }

--- a/src/main/java/com/hypherionmc/craterlib/impl/compat/ftb/FTBRanksImpl.java
+++ b/src/main/java/com/hypherionmc/craterlib/impl/compat/ftb/FTBRanksImpl.java
@@ -24,12 +24,14 @@ public class FTBRanksImpl implements FTBRanks {
     @Override
     public List<FTBRankImpl> getPlayerRanks(CraterGameProfile profile) {
         return FTBRanksAPI.manager().getAddedRanks(((BridgedGameProfile) profile).toNameAndId()).stream().map(FTBRankImpl::wrap).toList();
+        // Explicitly added ranks via "/ftbranks add player rank"
     }
 
     @Override
     public List<FTBRankImpl> getPlayerRanks(CraterPlayer player) {
         ServerPlayer serverPlayer = player.unwrap();
         return FTBRanksAPI.manager().getRanks(serverPlayer).stream().map(FTBRankImpl::wrap).toList();
+        // All ranks the player has. Includes explicitly added ranks and condition-added ranks.
     }
 
     public List<FTBRankImpl> getAllRanks() {
@@ -41,6 +43,7 @@ public class FTBRanksImpl implements FTBRanks {
         return getPlayerRanks(profile)
                 .stream()
                 .anyMatch(r -> r.unwrapInternal().getName().equalsIgnoreCase(rank) || r.unwrapInternal().getId().equalsIgnoreCase(rank));
+        //Original method for compatibility and for SDLink Discord2Minecraft
     }
     
     @Override
@@ -48,6 +51,7 @@ public class FTBRanksImpl implements FTBRanks {
         return getPlayerRanks(player)
                 .stream()
                 .anyMatch(r -> r.unwrapInternal().getName().equalsIgnoreCase(rank) || r.unwrapInternal().getId().equalsIgnoreCase(rank));
+        //Updated Method using ServerPlayer
     }
 
     public boolean addRank(CraterGameProfile profile, String rank) {


### PR DESCRIPTION
This PR adds support for querying a player's active FTB Ranks, including ranks granted by conditions.

Currently, getPlayerRanks(CraterGameProfile) uses RankManager.getAddedRanks(...), which only returns explicitly assigned ranks. This means integrations cannot detect ranks granted by FTB Ranks conditions.

Changes
Added getPlayerRanks(CraterPlayer) to the FTB Ranks compatibility API.
Implemented the new method using RankManager.getRanks(ServerPlayer) to return all active/effective ranks.
Added hasRank(CraterPlayer, String) for checking active ranks.
Preserved the existing CraterGameProfile methods for backward compatibility and for integrations that work with explicitly assigned ranks.

Tested
Verified that getPlayerRanks(CraterPlayer) returns condition-based ranks that are not present in getAddedRanks(...).